### PR TITLE
Share ERD Diagrams via URl

### DIFF
--- a/app/javascript/controllers/erd_controller.js
+++ b/app/javascript/controllers/erd_controller.js
@@ -317,6 +317,37 @@ export default class extends Controller {
     }
   }
 
+  shareSchema() {
+    const schema = this.inputTarget.value
+    if (!schema || !schema.trim()) {
+      alert('No schema to share. Please add your schema first.')
+      return
+    }
+
+    try {
+      // Encode UTF-8 string to Base64 (handles Unicode characters)
+      const utf8Bytes = new TextEncoder().encode(schema)
+      const binaryString = Array.from(utf8Bytes, byte => String.fromCharCode(byte)).join('')
+      const encoded = btoa(binaryString)
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/g, '') // Remove padding
+
+      const url = `${window.location.origin}${window.location.pathname}#schema=${encoded}`
+
+      // Copy to clipboard
+      navigator.clipboard.writeText(url).then(() => {
+        alert('Share link copied to clipboard!')
+      }).catch(() => {
+        // Fallback: show URL in prompt for manual copy
+        prompt('Copy this URL to share:', url)
+      })
+    } catch (e) {
+      console.error('Failed to generate share link:', e)
+      alert('Failed to generate share link. Schema might be too large.')
+    }
+  }
+
   render(graph) {
     const tables = graph.nodes.map((n, i) => ({
       id: n.id,

--- a/app/views/erd/index.html.erb
+++ b/app/views/erd/index.html.erb
@@ -60,10 +60,18 @@
       </div>
       <div class="flex-1 relative overflow-auto">
         <svg data-erd-target="svg" class="block min-w-full min-h-full"></svg>
-        <a href="https://github.com/siaw23/railserd/" target="_blank" rel="noopener noreferrer"
-           class="absolute top-3 left-3 inline-flex items-center justify-center h-8 w-8 rounded-md bg-white/90 hover:bg-white text-gray-700 shadow border border-gray-200">
-          <i data-lucide="github" class="w-4 h-4"></i>
-        </a>
+        <div class="absolute top-3 left-3 flex gap-2">
+          <a href="https://github.com/siaw23/railserd/" target="_blank" rel="noopener noreferrer"
+             class="inline-flex items-center justify-center h-8 w-8 rounded-md bg-white/90 hover:bg-white text-gray-700 shadow border border-gray-200">
+            <i data-lucide="github" class="w-4 h-4"></i>
+          </a>
+          <button type="button"
+                  class="inline-flex items-center justify-center h-8 w-8 rounded-md bg-red-600 hover:bg-red-700 text-white shadow border border-red-700"
+                  data-action="click->erd#shareSchema"
+                  title="Share this schema via URL">
+            <i data-lucide="share-2" class="w-4 h-4"></i>
+          </button>
+        </div>
         <div class="fixed bottom-4 right-4 flex flex-row gap-2 z-50">
           <button type="button" class="px-3 py-2 rounded-md bg-white shadow border border-gray-200 text-gray-700 hover:bg-gray-50"
                   data-action="click->erd#zoomIn" title="Zoom in">


### PR DESCRIPTION
Implements client-side schema sharing via URL fragments, allowing users to share their ERD diagrams with others through a simple shareable link. Issue: #8 


## Features

* Share Button: New share button positioned next to the GitHub icon in the top-left corner
* One-Click Sharing: Click the share button to generate and copy a shareable URL to clipboard
* Privacy-First: Uses URL fragments (#schema=...) instead of query parameters, ensuring schema data never reaches the server
* Unicode Support: Properly handles UTF-8 characters including emojis and special characters using TextEncoder/TextDecoder
* Large Schema Support: URL fragments support ~65KB+ of data, far exceeding query parameter limits
* Auto-Load: Opening a share URL automatically loads and renders the encoded schema
* Clean URLs: Automatically removes the hash fragment after loading to keep the URL clean


## Technical Implementation

Encoding (shareSchema() method):
- Validates schema exists before sharing
- Encodes UTF-8 string to Base64 using TextEncoder
- Converts to URL-safe Base64 (replaces + with -, / with _, removes padding)
- Generates shareable URL with fragment: http://localhost:3000/#schema=...
- Copies to clipboard with fallback to prompt if clipboard API fails


Decoding (getSchemaFromURL() function):

- Extracts Base64-encoded schema from URL hash
- Converts URL-safe Base64 back to standard Base64
- Decodes using atob() and TextDecoder for UTF-8 support
- Returns decoded schema to Monaco Editor
- Cleans URL after successful load